### PR TITLE
createFrame メソッドを呼び出す際にGameWindowのインスタンスをcreateFrameメソッドに渡すようにしたら解決できました。

### DIFF
--- a/src/main/java/factory/FrameFactory.java
+++ b/src/main/java/factory/FrameFactory.java
@@ -7,9 +7,7 @@ import window.GameWindow;
 import javax.swing.*;
 
 public class FrameFactory {
-    static GameWindow gameWindow = new GameWindow();
-
-    public static GameFrame createFrame(FrameSize size) {
+    public static GameFrame createFrame(FrameSize size, GameWindow gameWindow) {
         return () -> {
             JFrame frame = new JFrame();
             frame.setResizable(false);

--- a/src/main/java/frame/GameFrame.java
+++ b/src/main/java/frame/GameFrame.java
@@ -2,6 +2,5 @@ package frame;
 
 @FunctionalInterface
 public interface GameFrame {
-
     void createFrame();
 }

--- a/src/main/java/game/Main.java
+++ b/src/main/java/game/Main.java
@@ -5,7 +5,7 @@ import window.Window;
 
 public class Main {
     public static void main(String[] args) {
-        Window gameFrame = new GameWindow();
+        Window gameFrame = GameWindow.getInstance();
         gameFrame.frame();
     }
 }

--- a/src/main/java/window/GameWindow.java
+++ b/src/main/java/window/GameWindow.java
@@ -13,18 +13,26 @@ import static frame.FrameApp.baseDisplay;
 
 public class GameWindow extends JPanel implements Window, Runnable {
 
-    private GameFrame gameFrame = FrameFactory.createFrame(baseDisplay());
+    private GameFrame gameFrame = FrameFactory.createFrame(baseDisplay(), this);
+    private static GameWindow instance;
     private PlayManager playManager = new PlayManager();
     private KeyHandler keyHandler = new KeyHandler();
     private Thread gameThread;
 
-    public GameWindow() {
+    private GameWindow() {
         this.setBackground(Color.BLACK);
         this.setDoubleBuffered(true);
         this.setFocusable(true);
         this.startThread();
         this.addKeyListener(keyHandler);
         this.setFocusable(true);
+    }
+
+    public static synchronized GameWindow getInstance() {
+        if (instance == null) {
+            instance = new GameWindow();
+        }
+        return instance;
     }
 
     @Override


### PR DESCRIPTION
# 実装されたGameWindowクラス内で`override`されたframeメソッド内

gameFrameのインスタンスのcreateFrameメソッドを呼び出しているのですが,MainクラスでGameWindowのインスタンスを呼び出して,さらにFrameFactoryクラスでstaticフィールドを定義したGameWindowのインスタンスを呼び出しているので,2つのスレッドが同時に動いている状態になっていることだと推測しました。

1秒間に60回描画されているので,2つのスレッドが同時に動いている状態で,テトリスのブロックも7種類が2つある状態でランダム生成されて,ゲームのプレイ中に1つのブロックが落ちてきているのにも関わらず,突然別のブロックが現れるのはそれが原因だと思いました。

# 修正前のコード

![スクリーンショット 2025-03-17 165747](https://github.com/user-attachments/assets/2e52d913-7ce5-40f3-8a60-43f5e985478a)

![スクリーンショット 2025-03-17 165803](https://github.com/user-attachments/assets/15875423-1d81-4929-8953-3e77955089f8)

# 修正後のコード

![スクリーンショット 2025-03-17 192925](https://github.com/user-attachments/assets/93a50813-ce61-4cee-941a-c9ef6ef890d0)
![スクリーンショット 2025-03-17 192941](https://github.com/user-attachments/assets/44edced9-db8e-47ab-9404-a7bfe7da9a3b)

![スクリーンショット 2025-03-17 193109](https://github.com/user-attachments/assets/e67e4267-f496-4039-a105-520dbb0d506c)

# 問題のブロックが突然出てくる状態

https://github.com/user-attachments/assets/fa7726fd-1926-42c7-ae6c-a60ce43b4584


# 問題解決した状態

https://github.com/user-attachments/assets/15a04c4e-1ead-4aac-b133-e5140fa52f84


